### PR TITLE
Add Leo Vivier

### DIFF
--- a/README.org
+++ b/README.org
@@ -129,6 +129,17 @@ that explicit).
     - auto-compile, borg, epkg, no-littering: https://github.com/emacscollective
     - emacsmirror: https://emacsmirror.net
     - magit: https://magit.vc
+- Leo Vivier
+  - github: https://github.com/zaeph
+  - twitter: https://twitter.com/zaeph
+  - blog: https://zaeph.net/
+  - donate:
+    - github: https://github.com/sponsors/zaeph
+    - IBAN: FR76 3000 3009 6100 0501 1688 996
+    - paypal: https://www.paypal.me/zaeph
+  - projects
+    - org-roam: https://www.orgroam.com/
+    - org-roam-bibtex: https://github.com/org-roam/org-roam-bibtex
 - Matus Goljer
   - github: https://github.com/Fuco1
   - blog: https://fuco1.github.io/


### PR DESCRIPTION
Hi there,

I've added myself to the list of maintainers.  The chief reason is that I'd like to publicise my ability to maintain `org` projects, especially those with which [`org-roam`](https://github.com/org-roam/org-roam) interacts (e.g. [`pdf-tools`](https://github.com/politza/pdf-tools) & [`org-noter`](https://github.com/weirdNox/org-noter)).