### PR TITLE
Update info for Matus Goljer and Thierry Volpiatto

### DIFF
--- a/README.org
+++ b/README.org
@@ -202,7 +202,7 @@ that explicit).
 - Thierry Volpiatto
   - github: https://github.com/thierryvolpiatto
   - donate
-    - patreon: https://www.patreon.com/emacshelm (temporarily disabled, see https://support.patreon.com/hc/en-us/articles/115004487843 for details)
+    - paypal: https://www.paypal.me/tvolpiatto
   - projects
     - helm: https://github.com/emacs-helm/helm
 - Ivan Yonchovski

--- a/README.org
+++ b/README.org
@@ -154,7 +154,7 @@ that explicit).
   - github: https://github.com/Fuco1
   - blog: https://fuco1.github.io/
   - donate
-    - patreon: https://www.patreon.com/user?u=3282358
+    - patreon: https://www.patreon.com/matusgoljer
     - paypal: https://www.paypal.me/MatusGoljer
   - projects
     - smartparens: https://github.com/Fuco1/smartparens


### PR DESCRIPTION
* Thierry Volpiatto donation link appears in https://github.com/thierryvolpiatto/thierryvolpiatto
* Matus Goljer patreon username link