### PR TITLE
Add paypal link

### DIFF
--- a/README.org
+++ b/README.org
@@ -210,6 +210,7 @@ that explicit).
   - github: https://github.com/wasamasa
   - donate
     - liberapay: https://liberapay.com/wasamasa/
+    - paypal: https://www.paypal.me/wasamasa
   - projects
     - circe: https://github.com/emacs-circe/circe
     - esxml: https://github.com/tali713/esxml


### PR DESCRIPTION
Someone on `#emacs` asked for a paypal.me link, so I'm adding it to the list as well.